### PR TITLE
fixed build path typo for independent platform

### DIFF
--- a/independent-platform-example-typescript/package.json
+++ b/independent-platform-example-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "homebridge-independent-platform-example",
   "version": "1.0.0",
   "description": "An example independent platform plugin for homebridge written in Typescript",
-  "main": "dist/dynamic-platform.js",
+  "main": "dist/independent-platform.js",
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "rimraf ./dist && tsc",


### PR DESCRIPTION
## :recycle: Current situation

Independent Platform example package.json had the Dynamic Platform example package.json's start path.

## :bulb: Proposed solution

Changed a single `dynamic` to `independent`

## :gear: Release Notes

Running the independent platform should work out of the box now with no issues like before.